### PR TITLE
Dev-for-v0.2.0

### DIFF
--- a/src/Binning.jl
+++ b/src/Binning.jl
@@ -52,12 +52,17 @@
     function nanbinmean!(MU::AbstractMatrix, N::AbstractMatrix, x::AbstractVector, y::AbstractMatrix, xmin::Number, xmax::Number, nbins::Integer)
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
+        ncols = size(y,2)
 
         # Make sure we don't have a segfault by filling beyond the length of N
         # in the @inbounds loop below
-        if length(MU) < nbins
-            nbins = length(MU)
-            @warn "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+        if size(MU,1) < nbins
+            nbins = size(MU,1)
+            @warn "size(MU,1) < nbins; any bins beyond size(MU,1) will not be filled"
+        end
+        if size(MU,2) < ncols
+            ncols = size(MU,2)
+            @warn "size(MU,2) < size(y,2); any columns beyond size(MU,2) will not be filled"
         end
 
         # Calculate the means for each bin, ignoring NaNs
@@ -67,7 +72,7 @@
             bin_index_float = (x[i] - xmin) * scalefactor
             if (0 < bin_index_float < nbins)
                 bin_index = ceil(Int, bin_index_float)
-                for j = 1:size(y,2)
+                for j = 1:ncols
                     if !isnan(y[i,j])
                         N[bin_index,j] += 1
                         MU[bin_index,j] += y[i,j]
@@ -185,12 +190,17 @@
     function nanbinwmean!(MU::AbstractMatrix, W::AbstractMatrix, x::AbstractVector, y::AbstractMatrix, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
+        ncols = size(y,2)
 
         # Make sure we don't have a segfault by filling beyond the length of N
         # in the @inbounds loop below
-        if length(MU) < nbins
-            nbins = length(MU)
-            @warn "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+        if size(MU,1) < nbins
+            nbins = size(MU,1)
+            @warn "size(MU,1) < nbins; any bins beyond size(MU,1) will not be filled"
+        end
+        if size(MU,2) < ncols
+            ncols = size(MU,2)
+            @warn "size(MU,2) < size(y,2); any columns beyond size(MU,2) will not be filled"
         end
 
         # Calculate the means for each bin, ignoring NaNs
@@ -200,7 +210,7 @@
             bin_index_float = (x[i] - xmin) * scalefactor
             if (0 < bin_index_float < nbins)
                 bin_index = ceil(Int, bin_index_float)
-                for j = 1:size(y,2)
+                for j = 1:ncols
                     if y[i,j]==y[i,j]
                         W[bin_index,j] += w[i]
                         MU[bin_index,j] += y[i,j]*w[i]

--- a/src/Binning.jl
+++ b/src/Binning.jl
@@ -267,7 +267,7 @@
         nbins = length(xedges) - 1
         t = Array{Bool}(undef, length(x))
         @inbounds for i = 1:nbins
-            t .= (binedges[i] .<= x .< binedges[i+1]) .& (y.==y)
+            t .= (xedges[i] .<= x .< xedges[i+1]) .& (y.==y)
             M[i] = any(t) ? median(y[t]) : float(eltype(A))(NaN)
             N[i] = count(t)
         end
@@ -278,7 +278,7 @@
         t = Array{Bool}(undef, length(x))
         tj = Array{Bool}(undef, length(x))
         @inbounds for i = 1:nbins
-            t .= binedges[i] .<= x .< binedges[i+1]
+            t .= xedges[i] .<= x .< xedges[i+1]
             for j = 1:size(y,2)
                 tj .= t .& .!isnan.(y[:,j])
                 M[i,j] = any(tj) ? median(y[tj,j]) : float(eltype(A))(NaN)

--- a/src/Binning.jl
+++ b/src/Binning.jl
@@ -26,6 +26,13 @@
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
 
+        # Make sure we don't have a segfault by filling beyond the length of N
+        # in the @inbounds loop below
+        if length(MU) < nbins
+            nbins = length(MU)
+            @warn "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+        end
+
         # Calculate the means for each bin, ignoring NaNs
         fill!(N, 0)
         fill!(MU, 0) # Fill the output array with zeros to start
@@ -45,6 +52,13 @@
     function nanbinmean!(MU::AbstractMatrix, N::AbstractMatrix, x::AbstractVector, y::AbstractMatrix, xmin::Number, xmax::Number, nbins::Integer)
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
+
+        # Make sure we don't have a segfault by filling beyond the length of N
+        # in the @inbounds loop below
+        if length(MU) < nbins
+            nbins = length(MU)
+            @warn "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+        end
 
         # Calculate the means for each bin, ignoring NaNs
         fill!(N, 0)
@@ -93,6 +107,17 @@
         ymin, ymax = extrema(yedges)
         δiδy = nybins / (ymax - ymin)
 
+        # Make sure we don't have a segfault by filling beyond the length of N
+        # in the @inbounds loop below
+        if size(MU, 1) < nybins
+            nybins = size(MU, 1)
+            @warn "size(MU, 1) < nybins; any y bins beyond size(MU, 1) will not be filled"
+        end
+        if size(MU, 2) < nxbins
+            nxbins = size(MU, 2)
+            @warn "size(MU, 2) < nxbins; any x bins beyond size(MU, 2) will not be filled"
+        end
+
         # Calculate the means for each bin, ignoring NaNs
         fill!(N, 0)
         fill!(MU, 0) # Fill the output array with zeros to start
@@ -134,6 +159,13 @@
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
 
+        # Make sure we don't have a segfault by filling beyond the length of N
+        # in the @inbounds loop below
+        if length(MU) < nbins
+            nbins = length(MU)
+            @warn "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+        end
+
         # Calculate the means for each bin, ignoring NaNs
         fill!(W, 0)
         fill!(MU, 0) # Fill the output array with zeros to start
@@ -153,6 +185,13 @@
     function nanbinwmean!(MU::AbstractMatrix, W::AbstractMatrix, x::AbstractVector, y::AbstractMatrix, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
+
+        # Make sure we don't have a segfault by filling beyond the length of N
+        # in the @inbounds loop below
+        if length(MU) < nbins
+            nbins = length(MU)
+            @warn "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+        end
 
         # Calculate the means for each bin, ignoring NaNs
         fill!(W, 0)

--- a/src/Binning.jl
+++ b/src/Binning.jl
@@ -2,15 +2,12 @@
 
     """
     ```julia
-    nanbinmean!(MU, [N], x, y, [w], xmin::Number, xmax::Number, nbins::Integer)
+    nanbinmean!(MU, [N], x, y, xmin::Number, xmax::Number, nbins::Integer)
     ```
     Ignoring NaNs, fill the array `MU` with the means (and optionally `N` with
     the counts) of non-NAN `y` values that fall into each of `nbins` equally
     spaced `x` bins between `xmin` and `xmax`, aligned with bin edges as
     `xmin`:(`xmax`-`xmin`)/`nbins`:`xmax`
-
-    If an optional array of weights [`w`] is specified, then `N` is required, and
-    will be filled with the sum of weights for each bin.
 
     The array of `x` data should given as a one-dimensional array (any subtype
     of AbstractVector) and `y` as either a 1-d or 2-d array (any subtype of
@@ -68,8 +65,30 @@
 
         return MU
     end
+    export nanbinmean!
+
+    """
+    ```julia
+    nanbinmean!(MU, W, x, y, w, xmin::Number, xmax::Number, nbins::Integer)
+    ```
+    Ignoring NaNs, fill the array `MU` with the weighted means (and `W` with
+    the sum of weight) of non-NAN `y` values that fall into each of `nbins`
+    equally-spaced `x` bins between `xmin` and `xmax`, aligned with bin edges as
+    `xmin`:(`xmax`-`xmin`)/`nbins`:`xmax`
+
+    If an optional array of weights [`w`] is specified, then `N` is required, and
+    will be filled with the sum of weights for each bin.
+
+    The array of `x` data should given as a one-dimensional array (any subtype
+    of AbstractVector) and `y` as either a 1-d or 2-d array (any subtype of
+    AbstractVecOrMat).
+
+    The output arrays `MU` and `N` must be the same size, and must have the same
+    number of columns as `y`; if `y` is a 2-d array (matrix), then each column of
+    `y` will be treated as a separate variable.
+    """
     # In-place binning with weights; y, W, MU as 1D vectors
-    function nanbinmean!(MU::AbstractVector, W::AbstractVector, x::AbstractVector, y::AbstractVector, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
+    function nanbinwmean!(MU::AbstractVector, W::AbstractVector, x::AbstractVector, y::AbstractVector, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
 
@@ -89,7 +108,7 @@
         return MU
     end
     # In-place binning with weights; y, W, MU as 2D matrices
-    function nanbinmean!(MU::AbstractMatrix, W::AbstractMatrix, x::AbstractVector, y::AbstractMatrix, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
+    function nanbinwmean!(MU::AbstractMatrix, W::AbstractMatrix, x::AbstractVector, y::AbstractMatrix, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
         # Calculate bin index from x value
         scalefactor = nbins / (xmax - xmin)
 
@@ -112,7 +131,6 @@
 
         return MU
     end
-    export nanbinmean!
 
 
     """
@@ -178,9 +196,9 @@
 
     """
     ```julia
-    nanbinmean(x, y, [w], xmin::Number, xmax::Number, nbins::Integer)
+    nanbinmean(x, y, xmin::Number, xmax::Number, nbins::Integer)
     ```
-    Ignoring NaNs, calculate the mean (optionally weighted) of `y` values that
+    Ignoring NaNs, calculate the mean of `y` values that
     fall into each of `nbins` equally spaced `x` bins between `xmin` and `xmax`,
     aligned with bin edges as `xmin`:(`xmax`-`xmin`)/`nbins`:`xmax`
 
@@ -194,12 +212,26 @@
         MU = Array{float(eltype(y))}(undef, nbins, size(y)[2:end]...)
         return nanbinmean!(MU, N, x, y, xmin, xmax, nbins)
     end
-    function nanbinmean(x::AbstractVector, y::AbstractVecOrMat, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
+    export nanbinmean
+
+    """
+    ```julia
+    nanbinwmean(x, y, xmin::Number, xmax::Number, nbins::Integer)
+    ```
+    Ignoring NaNs, calculate the weighted mean of `y` values that
+    fall into each of `nbins` equally spaced `x` bins between `xmin` and `xmax`,
+    aligned with bin edges as `xmin`:(`xmax`-`xmin`)/`nbins`:`xmax`
+
+    The array of `x` data should given as a one-dimensional array (any subtype
+    of AbstractVector) and `y` as either a 1-d or 2-d array (any subtype of
+    AbstractVecOrMat). If `y` is a 2-d array, then each column of `y` will be
+    treated as a separate variable.
+    """
+    function nanbinwmean(x::AbstractVector, y::AbstractVecOrMat, w::AbstractVector, xmin::Number, xmax::Number, nbins::Integer)
         W = Array{float(eltype(y))}(undef, nbins, size(y)[2:end]...)
         MU = Array{float(eltype(y))}(undef, nbins, size(y)[2:end]...)
-        return nanbinmean!(MU, W, x, y, w, xmin, xmax, nbins)
+        return nanbinwmean!(MU, W, x, y, w, xmin, xmax, nbins)
     end
-    export nanbinmean
 
     """
     ```julia

--- a/src/Binning.jl
+++ b/src/Binning.jl
@@ -65,6 +65,8 @@
 
         return MU
     end
+    nanbinmean!(MU, x, y, xedges::AbstractRange) = nanbinmean!(MU, x, y, minimum(xedges), maximum(xedges), length(xedges)-1)
+    nanbinmean!(MU, N, x, y, xedges::AbstractRange) = nanbinmean!(MU, N, x, y, minimum(xedges), maximum(xedges), length(xedges)-1)
     export nanbinmean!
 
     """
@@ -75,9 +77,6 @@
     the sum of weight) of non-NAN `y` values that fall into each of `nbins`
     equally-spaced `x` bins between `xmin` and `xmax`, aligned with bin edges as
     `xmin`:(`xmax`-`xmin`)/`nbins`:`xmax`
-
-    If an optional array of weights [`w`] is specified, then `N` is required, and
-    will be filled with the sum of weights for each bin.
 
     The array of `x` data should given as a one-dimensional array (any subtype
     of AbstractVector) and `y` as either a 1-d or 2-d array (any subtype of
@@ -131,6 +130,7 @@
 
         return MU
     end
+    nanbinwmean!(MU, W, x, y, w, xedges::AbstractRange) = nanbinwmean!(MU, W, x, y, w, minimum(xedges), maximum(xedges), length(xedges)-1)
 
 
     """
@@ -189,6 +189,8 @@
         end
         return M
     end
+    nanbinmedian!(MU, x, y, xedges::AbstractRange) = nanbinmedian!(MU, x, y, minimum(xedges), maximum(xedges), length(xedges)-1)
+    nanbinmedian!(MU, N, x, y, xedges::AbstractRange) = nanbinmedian!(MU, N, x, y, minimum(xedges), maximum(xedges), length(xedges)-1)
     export nanbinmedian!
 
 
@@ -212,6 +214,7 @@
         MU = Array{float(eltype(y))}(undef, nbins, size(y)[2:end]...)
         return nanbinmean!(MU, N, x, y, xmin, xmax, nbins)
     end
+    nanbinmean(x, y, xedges::AbstractRange) = nanbinmean(x, y, minimum(xedges), maximum(xedges), length(xedges)-1)
     export nanbinmean
 
     """
@@ -232,6 +235,7 @@
         MU = Array{float(eltype(y))}(undef, nbins, size(y)[2:end]...)
         return nanbinwmean!(MU, W, x, y, w, xmin, xmax, nbins)
     end
+    nanbinwmean(x, y, w, xedges::AbstractRange) = nanbinwmean(x, y, w, minimum(xedges), maximum(xedges), length(xedges)-1)
 
     """
     ```julia
@@ -247,6 +251,7 @@
         M = Array{float(eltype(y))}(undef, nbins, size(y)[2:end]...)
         return nanbinmedian!(M, x, y, xmin, xmax, nbins)
     end
+    nanbinmedian(x, y, xedges::AbstractRange) = nanbinmedian(x, y, minimum(xedges), maximum(xedges), length(xedges)-1)
     export nanbinmedian
 
 

--- a/src/Histograms.jl
+++ b/src/Histograms.jl
@@ -11,14 +11,15 @@ function histcounts!(N::Array, x::AbstractArray, xedges::AbstractRange)
     # What is the size of each bin?
     nbins = length(xedges) - 1
     xmin, xmax = extrema(xedges)
-    binwidth = (xmax-xmin)/nbins
+    δiδx = nbins/(xmax-xmin)
 
     # Loop through each element of x
     @inbounds for i ∈ eachindex(x)
         xᵢ = x[i]
         if xᵢ==xᵢ # If not a NaN
-            binindex = Integer((xᵢ - xmin) ÷ binwidth) + 1
-            if 1 <= binindex <= nbins
+            δi = (xᵢ - xmin) * δiδx
+            if 0 < δi <= nbins
+                binindex = ceil(Int, δi)
                 N[binindex] += 1
             end
         end
@@ -29,13 +30,14 @@ function histcounts!(N::Array, x::AbstractArray{<:Integer}, xedges::AbstractRang
     # What is the size of each bin?
     nbins = length(xedges) - 1
     xmin, xmax = extrema(xedges)
-    binwidth = (xmax-xmin)/nbins
+    δiδx = nbins/(xmax-xmin)
 
     # Loop through each element of x
     @inbounds for i ∈ eachindex(x)
         xᵢ = x[i]
-        binindex = Integer((xᵢ - xmin) ÷ binwidth) + 1
-        if 1 <= binindex <= nbins
+        δi = (xᵢ - xmin) * δiδx
+        if 0 < δi <= nbins
+            binindex = ceil(Int, δi)
             N[binindex] += 1
         end
     end

--- a/src/Histograms.jl
+++ b/src/Histograms.jl
@@ -13,6 +13,13 @@ function histcounts!(N::Array, x::AbstractArray, xedges::AbstractRange)
     xmin, xmax = extrema(xedges)
     δiδx = nbins/(xmax-xmin)
 
+    # Make sure we don't have a segfault by filling beyond the length of N
+    # in the @inbounds loop below
+    if length(N) < nbins
+        nbins = length(N)
+        @warn "length(N) < nbins; any histogram bins beyond length(N) will not be filled"
+    end
+
     # Loop through each element of x
     @inbounds for i ∈ eachindex(x)
         xᵢ = x[i]
@@ -31,6 +38,13 @@ function histcounts!(N::Array, x::AbstractArray{<:Integer}, xedges::AbstractRang
     nbins = length(xedges) - 1
     xmin, xmax = extrema(xedges)
     δiδx = nbins/(xmax-xmin)
+
+    # Make sure we don't have a segfault by filling beyond the length of N
+    # in the @inbounds loop below
+    if length(N) < nbins
+        nbins = length(N)
+        @warn "length(N) < nbins; any histogram bins beyond length(N) will not be filled"
+    end
 
     # Loop through each element of x
     @inbounds for i ∈ eachindex(x)

--- a/src/Histograms.jl
+++ b/src/Histograms.jl
@@ -57,5 +57,4 @@ function histcounts!(N::Array, x::AbstractArray{<:Integer}, xedges::AbstractRang
     end
     return N
 end
-histcounts!(N, x, xmin::Number, xmax::Number, nbins::Integer; T=Int64) = histcounts!(N, x, range(xmin, xmax, length=nbins+1); T=T)
 export histcounts!

--- a/src/Histograms.jl
+++ b/src/Histograms.jl
@@ -1,18 +1,16 @@
-function histcounts(x::AbstractArray, xmin, xmax, nbins; T=Int64)
-    N = fill(zero(T), nbins)
-    histcounts!(N, x, xmin, xmax, nbins)
-    return N
-end
+
 function histcounts(x::AbstractArray, xedges::AbstractRange; T=Int64)
-    nbins = length(xedges)-1
-    N = fill(zero(T), nbins)
-    histcounts!(N, x, minimum(xedges), maximum(xedges), nbins)
+    N = fill(zero(T), length(xedges)-1)
+    histcounts!(N, x, xedges)
     return N
 end
+histcounts(x, xmin::Number, xmax::Number, nbins::Integer; T=Int64) = histcounts(x, range(xmin, xmax, length=nbins+1); T=T)
 export histcounts
 
-function histcounts!(N::Array, x::AbstractArray, xmin, xmax, nbins)
+function histcounts!(N::Array, x::AbstractArray, xedges::AbstractRange)
     # What is the size of each bin?
+    nbins = length(xedges) - 1
+    xmin, xmax = extrema(xedges)
     binwidth = (xmax-xmin)/nbins
 
     # Loop through each element of x
@@ -27,8 +25,10 @@ function histcounts!(N::Array, x::AbstractArray, xmin, xmax, nbins)
     end
     return N
 end
-function histcounts!(N::Array, x::AbstractArray{<:Integer}, xmin, xmax, nbins)
+function histcounts!(N::Array, x::AbstractArray{<:Integer}, xedges::AbstractRange)
     # What is the size of each bin?
+    nbins = length(xedges) - 1
+    xmin, xmax = extrema(xedges)
     binwidth = (xmax-xmin)/nbins
 
     # Loop through each element of x
@@ -41,4 +41,5 @@ function histcounts!(N::Array, x::AbstractArray{<:Integer}, xmin, xmax, nbins)
     end
     return N
 end
+histcounts!(N, x, xmin::Number, xmax::Number, nbins::Integer; T=Int64) = histcounts!(N, x, range(xmin, xmax, length=nbins+1); T=T)
 export histcounts!

--- a/src/Histograms.jl
+++ b/src/Histograms.jl
@@ -17,7 +17,7 @@ function histcounts!(N::Array, x::AbstractArray, xedges::AbstractRange)
     # in the @inbounds loop below
     if length(N) < nbins
         nbins = length(N)
-        @warn "length(N) < nbins; any histogram bins beyond length(N) will not be filled"
+        @warn "length(N) < nbins; any bins beyond length(N) will not be filled"
     end
 
     # Loop through each element of x
@@ -43,7 +43,7 @@ function histcounts!(N::Array, x::AbstractArray{<:Integer}, xedges::AbstractRang
     # in the @inbounds loop below
     if length(N) < nbins
         nbins = length(N)
-        @warn "length(N) < nbins; any histogram bins beyond length(N) will not be filled"
+        @warn "length(N) < nbins; any bins beyond length(N) will not be filled"
     end
 
     # Loop through each element of x

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -9,24 +9,30 @@
 
     # Means
     @test nanbinmean([1:100..., 1], [1:100..., NaN], 0, 100, 3) == [17, 50, 83]
+    @test nanbinmean([1:100..., 1], [1:100..., NaN], range(0,100,length=4)) == [17, 50, 83]
     nanbinmean!(M3, N3, [1:100..., 1],[1:100..., NaN],0,100,3)
     @test M3 == [17, 50, 83]
     @test N3 == fill(33,3)
     @test nanbinmean(1:100, reshape(1:300,100,3), 0, 100, 3) == r
+    @test nanbinmean(1:100, reshape(1:300,100,3), range(0,100,length=4)) == r
 
     # Weighted means
     @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(100), 0,100,3) == [17, 50, 83]
+    @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(100), range(0,100,length=4)) == [17, 50, 83]
     @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(100), 0, 100, 3) == r
+    @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(100), range(0,100,length=4)) == r
     NaNStatistics.nanbinwmean!(M33, N33, 1:100, reshape(1:300,100,3), ones(100), 0, 100, 3)
     @test M33 == r
     @test N33 == fill(33,3,3)
 
     # Medians
     @test nanbinmedian([1:100..., 1],[1:100..., NaN],0,100,3) == [17, 50, 83]
+    @test nanbinmedian([1:100..., 1],[1:100..., NaN],range(0,100,length=4)) == [17, 50, 83]
     nanbinmedian!(M3, N3, [1:100..., 1],[1:100..., NaN],0,100,3)
     @test M3 == [17, 50, 83]
     @test N3 == fill(33,3)
     @test nanbinmedian(1:100, reshape(1:300,100,3), 0, 100, 3) == r
+    @test nanbinmedian(1:100, reshape(1:300,100,3), range(0,100,length=4)) == r
     nanbinmedian!(M33, N33, 1:100, reshape(1:300,100,3), 0, 100, 3)
     @test M33 == r
     @test N33 == fill(33,3,3)

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -17,11 +17,11 @@
     @test nanbinmean(1:100, reshape(1:300,100,3), range(0,100,length=4)) == r
 
     # Weighted means
-    @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(100), 0,100,3) == [17, 50, 83]
-    @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(100), range(0,100,length=4)) == [17, 50, 83]
-    @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(100), 0, 100, 3) == r
-    @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(100), range(0,100,length=4)) == r
-    NaNStatistics.nanbinwmean!(M33, N33, 1:100, reshape(1:300,100,3), ones(100), 0, 100, 3)
+    @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(101), 0,100,3) == [17, 50, 83]
+    @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(101), range(0,100,length=4)) == [17, 50, 83]
+    @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(101), 0, 100, 3) == r
+    @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(101), range(0,100,length=4)) == r
+    NaNStatistics.nanbinwmean!(M33, N33, 1:100, reshape(1:300,100,3), ones(101), 0, 100, 3)
     @test M33 == r
     @test N33 == fill(33,3,3)
 
@@ -44,7 +44,9 @@
     @test isequal(mu, [((i==j) ? i-0.5 : NaN) for i in 1:10, j in 1:10])
 
 
-    # Test results and warnings when N is too small to hold results
+## --- Test results and warnings when N is too small to hold results
+
+    # Means
     M2 = zeros(2)
     N2 = fill(0,2)
     w = "length(MU) < nbins; any bins beyond length(MU) will not be filled"
@@ -53,7 +55,6 @@
     @test_logs (:warn, w) nanbinmean!(M2, N2, 1:100,1:100,0,100,3)
     @test M2 == [17, 50]
 
-    # Multiple-dependent-variables-at-once case
     M23 = zeros(2,3)
     N23 = fill(0,2,3)
     w = "size(MU,1) < nbins; any bins beyond size(MU,1) will not be filled"
@@ -61,6 +62,24 @@
     @test M23 == r[1:2,1:3]
     w = "size(MU,2) < size(y,2); any columns beyond size(MU,2) will not be filled"
     @test_logs (:warn, w) nanbinmean!(M23', N23', 1:100, reshape(1:300,100,3), 0, 100, 3)
+    @test M23' == r[1:3,1:2]
+
+    # Weighted Means
+    M2 = zeros(2)
+    N2 = fill(0,2)
+    w = "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+    @test_logs (:warn, w) NaNStatistics.nanbinwmean!(M2, N2, [1:100..., 1],[1:100..., NaN],ones(101), 0,100,3)
+    @test M2 == [17, 50]
+    @test_logs (:warn, w) NaNStatistics.nanbinwmean!(M2, N2, 1:100,1:100,ones(101), 0,100,3)
+    @test M2 == [17, 50]
+
+    M23 = zeros(2,3)
+    N23 = fill(0,2,3)
+    w = "size(MU,1) < nbins; any bins beyond size(MU,1) will not be filled"
+    @test_logs (:warn, w) NaNStatistics.nanbinwmean!(M23, N23, 1:100, reshape(1:300,100,3), ones(101), 0, 100, 3)
+    @test M23 == r[1:2,1:3]
+    w = "size(MU,2) < size(y,2); any columns beyond size(MU,2) will not be filled"
+    @test_logs (:warn, w) NaNStatistics.nanbinwmean!(M23', N23', 1:100, reshape(1:300,100,3), ones(101), 0, 100, 3)
     @test M23' == r[1:3,1:2]
 
     # 2D case

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -13,6 +13,8 @@
     nanbinmean!(M3, N3, [1:100..., 1],[1:100..., NaN],0,100,3)
     @test M3 == [17, 50, 83]
     @test N3 == fill(33,3)
+    nanbinmean!(M3,[1:100..., 1],[1:100..., NaN],0,100,3)
+    @test M3 == [17, 50, 83]
     @test nanbinmean(1:100, reshape(1:300,100,3), 0, 100, 3) == r
     @test nanbinmean(1:100, reshape(1:300,100,3), range(0,100,length=4)) == r
 

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -43,4 +43,32 @@
     mu = nanbinmean(x,y,z,xedges,yedges)
     @test isequal(mu, [((i==j) ? i-0.5 : NaN) for i in 1:10, j in 1:10])
 
+
+    # Test results and warnings when N is too small to hold results
+    M2 = zeros(2)
+    N2 = fill(0,2)
+    w = "length(MU) < nbins; any bins beyond length(MU) will not be filled"
+    @test_logs (:warn, w) nanbinmean!(M2, N2, [1:100..., 1],[1:100..., NaN],0,100,3)
+    @test M2 == [17, 50]
+    @test_logs (:warn, w) nanbinmean!(M2, N2, 1:100,1:100,0,100,3)
+    @test M2 == [17, 50]
+
+    # Multiple-dependent-variables-at-once case
+    M23 = zeros(2,3)
+    N23 = fill(0,2,3)
+    w = "size(MU,1) < nbins; any bins beyond size(MU,1) will not be filled"
+    @test_logs (:warn, w) nanbinmean!(M23, N23, 1:100, reshape(1:300,100,3), 0, 100, 3)
+    @test M23 == r[1:2,1:3]
+    w = "size(MU,2) < size(y,2); any columns beyond size(MU,2) will not be filled"
+    @test_logs (:warn, w) nanbinmean!(M23', N23', 1:100, reshape(1:300,100,3), 0, 100, 3)
+    @test M23' == r[1:3,1:2]
+
+    # 2D case
+    x = y = z = 0.5:9.5
+    xedges = yedges = 0:10
+    w1 = "size(MU, 1) < nybins; any y bins beyond size(MU, 1) will not be filled"
+    w2 = "size(MU, 2) < nxbins; any x bins beyond size(MU, 2) will not be filled"
+    @test_logs (:warn, w1) (:warn, w2) nanbinmean!(M33, N33, x,y,z,xedges,yedges)
+    @test isequal(M33, [((i==j) ? i-0.5 : NaN) for i in 1:3, j in 1:3])
+
 ## -- End of File

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -17,7 +17,7 @@
     # Weighted means
     @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(100), 0,100,3) == [17, 50, 83]
     @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(100), 0, 100, 3) == r
-    NaNStatistics.nanbinwmean!(M33, N33, 1:100, reshape(1:300,100,3), 0, 100, 3)
+    NaNStatistics.nanbinwmean!(M33, N33, 1:100, reshape(1:300,100,3), ones(100), 0, 100, 3)
     @test M33 == r
     @test N33 == fill(33,3,3)
 

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -37,4 +37,10 @@
     @test M33 == r
     @test N33 == fill(33,3,3)
 
+    # 2D Means
+    x = y = z = 0.5:9.5
+    xedges = yedges = 0:10
+    mu = nanbinmean(x,y,z,xedges,yedges)
+    @test isequal(mu, [((i==j) ? i-0.5 : NaN) for i in 1:10, j in 1:10])
+
 ## -- End of File

--- a/test/testBinning.jl
+++ b/test/testBinning.jl
@@ -15,9 +15,9 @@
     @test nanbinmean(1:100, reshape(1:300,100,3), 0, 100, 3) == r
 
     # Weighted means
-    @test nanbinmean([1:100..., 1], [1:100..., NaN], ones(100), 0,100,3) == [17, 50, 83]
-    @test nanbinmean(1:100, reshape(1:300,100,3), ones(100), 0, 100, 3) == r
-    nanbinmean!(M33, N33, 1:100, reshape(1:300,100,3), 0, 100, 3)
+    @test NaNStatistics.nanbinwmean([1:100..., 1], [1:100..., NaN], ones(100), 0,100,3) == [17, 50, 83]
+    @test NaNStatistics.nanbinwmean(1:100, reshape(1:300,100,3), ones(100), 0, 100, 3) == r
+    NaNStatistics.nanbinwmean!(M33, N33, 1:100, reshape(1:300,100,3), 0, 100, 3)
     @test M33 == r
     @test N33 == fill(33,3,3)
 

--- a/test/testHistograms.jl
+++ b/test/testHistograms.jl
@@ -1,11 +1,12 @@
 N = 10000
 
 a = rand(N)
-h = histcounts(a, 0, 1, 10)
-@test h == histcounts(a, 0:0.1:1)
+h = histcounts(a, 0:0.1:1)
+@test h == histcounts(a, 0, 1, 10)
 @test isa(h, Array{Int64,1})
 @test length(h) == 10
 @test sum(h) == N
 
+@test histcounts(0:99,0:10:100) == fill(10,10)
 @test histcounts(0:99,0,100,10) == fill(10,10)
 @test histcounts(0:99.,0.,100.,10) == fill(10,10)

--- a/test/testHistograms.jl
+++ b/test/testHistograms.jl
@@ -10,3 +10,8 @@ h = histcounts(a, 0:0.1:1)
 @test histcounts(1:100,0:10:100) == fill(10,10)
 @test histcounts(1:100,0,100,10) == fill(10,10)
 @test histcounts(1:100.,0.,100.,10) == fill(10,10)
+
+# Test results and warnings when N is too small to hold results
+w = "length(N) < nbins; any bins beyond length(N) will not be filled"
+@test (@test_logs (:warn, w) histcounts!(zeros(5), 1:100 ,0:10:100)) == fill(10,5)
+@test (@test_logs (:warn, w) histcounts!(zeros(5), 1:100. ,0:10:100)) == fill(10,5)

--- a/test/testHistograms.jl
+++ b/test/testHistograms.jl
@@ -7,6 +7,6 @@ h = histcounts(a, 0:0.1:1)
 @test length(h) == 10
 @test sum(h) == N
 
-@test histcounts(0:99,0:10:100) == fill(10,10)
-@test histcounts(0:99,0,100,10) == fill(10,10)
-@test histcounts(0:99.,0.,100.,10) == fill(10,10)
+@test histcounts(1:100,0:10:100) == fill(10,10)
+@test histcounts(1:100,0,100,10) == fill(10,10)
+@test histcounts(1:100.,0.,100.,10) == fill(10,10)


### PR DESCRIPTION
Changes and bugfixes intended for v0.2.0. 
* Favor interface that uses range of `xedges` to define bin edges rather than `xmin`, `xmax`, `nbins`
* Check destination bounds before running in-place binning and histogram methods, warn if applicable
* more efficient binning method for `histcounts`