### PR TITLE
Don't dispatch on `VectorizationBase.Vec`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]
 IfElse = "0.1"
-LoopVectorization = "0.12.42"
+LoopVectorization = "0.12.106"
 Static = "0.2, 0.3, 0.4, 0.5, 0.6"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,11 @@ version = "0.6.9"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
 IfElse = "0.1"
 LoopVectorization = "0.12.42"
 Static = "0.2, 0.3, 0.4, 0.5, 0.6"
-VectorizationBase = "0.20, 0.21"
 julia = "1.6"
 
 [extras]

--- a/src/ArrayStats/ArrayStats.jl
+++ b/src/ArrayStats/ArrayStats.jl
@@ -89,9 +89,7 @@
     ```
     As `max(a,b)`, but if either argument is `NaN`, return the other one
     """
-    nanmax(a, b) = ifelse(a > b, a, b)
-    nanmax(a, b::AbstractFloat) = ifelse(a==a, ifelse(b > a, b, a), b)
-    nanmax(a, b::Vec{N,<:AbstractFloat}) where N = ifelse(a==a, ifelse(b > a, b, a), b)
+    nanmax(a, b) = ifelse(a==a, ifelse(b > a, b, a), b)
     export nanmax
 
     """
@@ -100,9 +98,7 @@
     ```
     As `min(a,b)`, but if either argument is `NaN`, return the other one
     """
-    nanmin(a, b) = ifelse(a < b, a, b)
-    nanmin(a, b::AbstractFloat) = ifelse(a==a, ifelse(b < a, b, a), b)
-    nanmin(a, b::Vec{N,<:AbstractFloat}) where N = ifelse(a==a, ifelse(b < a, b, a), b)
+    nanmin(a, b) = ifelse(a==a, ifelse(b < a, b, a), b)
     export nanmin
 
 ## --- Percentile statistics, excluding NaNs

--- a/src/NaNStatistics.jl
+++ b/src/NaNStatistics.jl
@@ -3,7 +3,6 @@ module NaNStatistics
     # AVX vectorziation tools
     using IfElse: ifelse
     using LoopVectorization
-    using VectorizationBase: Vec
 
     using Static
     _dim(::Type{StaticInt{N}}) where {N} = N::Int

--- a/test/testArrayStats.jl
+++ b/test/testArrayStats.jl
@@ -16,6 +16,13 @@
     @test nanadd!(A,B) == 1:20
     @test zeronan!(B) == [fill(0,10); 11:20]
 
+    # Test arrays that are mostly NaN
+    x = [1.:100;]
+    x[34:end] .= NaN
+    @test nanminimum(x) == 1
+    @test nanmaximum(x) == 33
+
+
 ## --- Summary statistics: simple cases, Float64
     A = [1:10.0..., NaN]
     @test nansum(A) == 55.0


### PR DESCRIPTION
The previous implementation of `nanmin` and `nanmax` dispatched on `VectorizationBase.Vec{N, <:AbstractFloat}` which was a convenient way to avoid unnecessary comparisons on arrays which didn't contain `AbstractFloat` and couldn't contain `NaN`s. 

However, at some point LoopVectorization.jl / VectorizationBase.jl appears to have started also (?) emitting a more complicated `VectorizationBase.VecUnroll` which hit the untyped fallback method in `nanmin`/`nanmax` which gave incorrect results.

To avoid that problem, this fix for now just treats everything as if it potentially contains `NaN`s, and makes no assumptions about the internals of LoopVectorzation / VectorizationBase so should be more robust to future changes at the minor cost of being a bit slower for arrays of integers.

Should test and fix #19 