### PR TITLE
fix Julia v1.9 @turbo empty iterator error of quickselect!, #35

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NaNStatistics"
 uuid = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
 authors = ["C. Brenhin Keller"]
-version = "0.6.26"
+version = "0.6.27"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
@@ -11,10 +11,10 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]
 IfElse = "0.1"
-LoopVectorization = "0.12.113"
+LoopVectorization = "0.12.159"
 PrecompileTools = "1"
 Static = "0.2 - 0.8"
-julia = "1.8"
+julia = "1.8, 1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 IfElse = "0.1"
 LoopVectorization = "0.12.159"
 PrecompileTools = "1"
-Static = "0.2 - 0.8"
+Static = "0.8.7"
 julia = "1.8, 1.9"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 IfElse = "0.1"
 LoopVectorization = "0.12.159"
 PrecompileTools = "1"
-Static = "0.8.7"
+Static = "0.8"
 julia = "1.8, 1.9"
 
 [extras]

--- a/src/Sorting/quicksort.jl
+++ b/src/Sorting/quicksort.jl
@@ -83,7 +83,7 @@ function quickselect!(A::AbstractArray, iₗ=firstindex(A), iᵤ=lastindex(A), k
     # Count up elements that must be moved to upper partition
     Nᵤ = 0
     @turbo for i = (iₗ+1):iᵤ
-        Nᵤ += A[i] >= pivot
+        Nᵤ += Int(A[i] >= pivot)
     end
     Nₗ = N - Nᵤ
 

--- a/src/Sorting/quicksort.jl
+++ b/src/Sorting/quicksort.jl
@@ -82,8 +82,12 @@ function quickselect!(A::AbstractArray, iₗ=firstindex(A), iᵤ=lastindex(A), k
 
     # Count up elements that must be moved to upper partition
     Nᵤ = 0
-    @turbo for i = (iₗ+1):iᵤ
-        Nᵤ += Int(A[i] >= pivot)
+    # @turbo 
+    @inbounds for i = (iₗ+1):iᵤ
+        if A[i] >= pivot
+            Nᵤ += 1  
+        end
+        # Nᵤ += Int(A[i] >= pivot)
     end
     Nₗ = N - Nᵤ
 

--- a/test/testSorting.jl
+++ b/test/testSorting.jl
@@ -140,6 +140,10 @@
     @test nanpctile!(copy(A), 50, dims=(2,3)) == median(A, dims=(2,3))
 
 ## ---
+    # test for n₋ >= 384
+    zi = collect(1:500)
+    @test NaNStatistics._nanquantile!(zi, 0.999, 1) == [499.501]
+    @test nanquantile(1:500, 0.999) ≈ 499.501
 
     @test nanquantile(0:10, 0) == 0
     @test nanquantile(0:10, 1/100) ≈ 0.1


### PR DESCRIPTION
This is a temporal solution for #35. 
If @turbo can accept empty iterator, this issue will be gone.

See details in [#LoopVectorization.jl/#492](https://github.com/JuliaSIMD/LoopVectorization.jl/issues/492)