### PR TITLE
Improve performance of nanmean/nansum on large arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /dev
 Manifest.toml
 .DS_Store
+
+# Output from AirspeedVelocity.jl
+results_*

--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,17 @@ StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
 
 [weakdeps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+Hwloc = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
+NaNStatisticsHwlocExt = "Hwloc"
 NaNStatisticsDimensionalDataExt = "DimensionalData"
 NaNStatisticsUnitfulExt = "Unitful"
 
 [compat]
 DimensionalData = "0.29"
+Hwloc = "3.3.0"
 PrecompileTools = "1"
 Static = "0.8, 1"
 StaticArrayInterface = "1"

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ currently don't are:
 - `nancor` and `nancov` (does work but won't preserve array metadata)
 - `nanstandardize` and `nanstandardize!` (completely unsupported)
 
+### Benchmarks
+We maintain a few benchmarks in `benchmark/benchmarks.jl` for use with
+[AirspeedVelocity.jl](https://astroautomata.com/AirspeedVelocity.jl). If you're
+developing the package and want to benchmark the current state of the code vs
+`main`, install AirspeedVelocity.jl and run `benchpkg`. See the
+AirspeedVelocity.jl docs for more information.
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: https://brenhinkeller.github.io/NaNStatistics.jl/stable/

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,30 @@
+using NaNStatistics
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Benchmark nanmean and nansum optimizations for large arrays and ensure they
+# don't effect performance on small arrays.
+SUITE["nanmean"] = BenchmarkGroup()
+SUITE["nansum"] = BenchmarkGroup()
+
+big::Array{Float64, 3} = rand(1000, 1000, 10)
+for i in rand(eachindex(big), 1000)
+    big[i] = NaN
+end
+
+small::Array{Float64, 3} = rand(10, 10, 10)
+for i in rand(eachindex(small), 50)
+    small[i] = NaN
+end
+
+small_vector::Vector{Float64} = rand(10)
+
+for i in 1:3
+    SUITE["nanmean"]["big array, dim $(i)"] = @benchmarkable nanmean($big; dim=$i)
+    SUITE["nanmean"]["small array, dim $(i)"] = @benchmarkable nanmean($small; dim=$i)
+    SUITE["nanmean"]["small vector"] = @benchmarkable nanmean($small_vector)
+    SUITE["nansum"]["big array, dim $(i)"] = @benchmarkable nansum($big; dim=$i)
+    SUITE["nansum"]["small array, dim $(i)"] = @benchmarkable nansum($small; dim=$i)
+    SUITE["nansum"]["small vector"] = @benchmarkable nansum($small_vector)
+end

--- a/ext/NaNStatisticsHwlocExt.jl
+++ b/ext/NaNStatisticsHwlocExt.jl
@@ -1,0 +1,15 @@
+module NaNStatisticsHwlocExt
+
+import Hwloc
+import NaNStatistics
+
+cache_sizes::@NamedTuple{L1::Int, L2::Int, L3::Int} = (; L1=0, L2=0, L3=0)
+
+NaNStatistics.get_size_threshold(x::Symbol) = cache_sizes[x]
+
+function __init__()
+    global cache_sizes = Hwloc.cachesize()
+    NaNStatistics.NANMEAN_SIZE_THRESHOLD = :L1
+end
+
+end

--- a/src/ArrayStats/nankurtosis.jl
+++ b/src/ArrayStats/nankurtosis.jl
@@ -45,7 +45,7 @@ export nankurtosis
 _nankurtosis(μ, corrected::Bool, A, dims::Int) = _nankurtosis(μ, corrected, A, (dims,))
 
 # If the mean isn't known, compute it
-_nankurtosis(::Nothing, corrected::Bool, A, dims::Tuple) = _nankurtosis!(_nanmean(A, dims), corrected, A, dims)
+_nankurtosis(::Nothing, corrected::Bool, A, dims::Tuple) = _nankurtosis!(_nanmean(A, dims, NANMEAN_SIZE_THRESHOLD), corrected, A, dims)
 # Reduce all the dims!
 function _nankurtosis(::Nothing, corrected::Bool, A, ::Colon)
     T = eltype(A)

--- a/src/ArrayStats/nanmean.jl
+++ b/src/ArrayStats/nanmean.jl
@@ -100,6 +100,11 @@ function staticdim_nanmean_quote(static_dims::Vector{Int}, N::Int)
         end
     end
 
+    # Reverse the axis lists so that we build up the loops from slow-axis to
+    # fast-axis for column major arrays.
+    reverse!(nonreduct_inds)
+    reverse!(reduct_inds)
+
     # Secondly, build up our set of loops
     firstn = first(nonreduct_inds)
     block = Expr(:block)

--- a/src/ArrayStats/nanmean.jl
+++ b/src/ArrayStats/nanmean.jl
@@ -76,110 +76,116 @@ end
 # Generate customized set of loops for a given ndims and a vector
 # `static_dims` of dimensions to reduce over
 function staticdim_nanmean_quote(static_dims::Vector{Int}, N::Int)
-  M = length(static_dims)
-  # `static_dims` now contains every dim we're taking the mean over.
-  Bᵥ = Expr(:call, :view, :B)
-  reduct_inds = Int[]
-  nonreduct_inds = Int[]
-  # Firstly, build our expressions for indexing each array
-  Aind = :(A[])
-  Bind = :(Bᵥ[])
-  inds = Vector{Symbol}(undef, N)
-  for n ∈ 1:N
-    ind = Symbol(:i_,n)
-    inds[n] = ind
-    push!(Aind.args, ind)
-    if n ∈ static_dims
-      push!(reduct_inds, n)
-      push!(Bᵥ.args, :(firstindex(B,$n)))
-    else
-      push!(nonreduct_inds, n)
-      push!(Bᵥ.args, :)
-      push!(Bind.args, ind)
+    M = length(static_dims)
+    # `static_dims` now contains every dim we're taking the mean over.
+    Bᵥ = Expr(:call, :view, :B)
+    reduct_inds = Int[]
+    nonreduct_inds = Int[]
+
+    # Firstly, build our expressions for indexing each array
+    Aind = :(A[])
+    Bind = :(Bᵥ[])
+    inds = Vector{Symbol}(undef, N)
+    for n ∈ 1:N
+        ind = Symbol(:i_,n)
+        inds[n] = ind
+        push!(Aind.args, ind)
+        if n ∈ static_dims
+            push!(reduct_inds, n)
+            push!(Bᵥ.args, :(firstindex(B,$n)))
+        else
+            push!(nonreduct_inds, n)
+            push!(Bᵥ.args, :)
+            push!(Bind.args, ind)
+        end
     end
-  end
-  firstn = first(nonreduct_inds)
-  # Secondly, build up our set of loops
-  block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
-  if length(nonreduct_inds) > 1
-    for n ∈ @view(nonreduct_inds[2:end])
-      newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
-      block = newblock
+
+    # Secondly, build up our set of loops
+    firstn = first(nonreduct_inds)
+    block = Expr(:block)
+    loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+    if length(nonreduct_inds) > 1
+        for n ∈ @view(nonreduct_inds[2:end])
+            newblock = Expr(:block)
+            push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+            block = newblock
+        end
     end
-  end
-  rblock = block
-  # Push more things here if you want them at the beginning of the reduction loop
-  push!(rblock.args, :(n = 0))
-  push!(rblock.args, :(Σ = ∅))
-  # Build the reduction loop
-  for n ∈ reduct_inds
-    newblock = Expr(:block)
-    if n==last(reduct_inds)
-      push!(block.args, Expr(:macrocall, Symbol("@simd"), :ivdep, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock)))
-    else
-      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
+
+    # Push more things here if you want them at the beginning of the reduction loop
+    rblock = block
+    push!(rblock.args, :(n = 0))
+    push!(rblock.args, :(Σ = ∅))
+    # Build the reduction loop
+    for n ∈ reduct_inds
+        newblock = Expr(:block)
+        if n==last(reduct_inds)
+            push!(block.args, Expr(:macrocall, Symbol("@simd"), :ivdep, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock)))
+        else
+            push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
+        end
+        block = newblock
     end
-    block = newblock
-  end
-  # Push more things here if you want them in the innermost loop
-  push!(block.args, :(Aᵢ = $Aind))
-  push!(block.args, :(notnan = Aᵢ==Aᵢ))
-  push!(block.args, :(n += notnan))
-  push!(block.args, :(Σ += ifelse(notnan, Aᵢ, ∅)))
-  # Push more things here if you want them at the end of the reduction loop
-  push!(rblock.args, :($Bind = Σ * inv(n)))
-  # Put it all together
-  quote
-    ∅ = zero(eltype(B))
-    Bᵥ = $Bᵥ
-    @inbounds $loops
-    return B
-  end
+
+    # Push more things here if you want them in the innermost loop
+    push!(block.args, :(Aᵢ = $Aind))
+    push!(block.args, :(notnan = Aᵢ==Aᵢ))
+    push!(block.args, :(n += notnan))
+    push!(block.args, :(Σ += ifelse(notnan, Aᵢ, ∅)))
+
+    # Push more things here if you want them at the end of the reduction loop
+    push!(rblock.args, :($Bind = Σ * inv(n)))
+
+    # Put it all together
+    quote
+        ∅ = zero(eltype(B))
+        Bᵥ = $Bᵥ
+        @inbounds $loops
+        return B
+    end
 end
 
 # Turn non-static integers in `dims` tuple into `StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nanmean_quote(N::Int, M::Int, D)
-  static_dims = Int[]
-  for m ∈ 1:M
-    param = D.parameters[m]
-    if param <: StaticInt
-      new_dim = _dim(param)::Int
-      @assert new_dim ∉ static_dims
-      push!(static_dims, new_dim)
-    else
-      t = Expr(:tuple)
-      for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
-      end
-      q = Expr(:block, :(dimm = dims[$m]))
-      qold = q
-      ifsym = :if
-      for n ∈ 1:N
-        n ∈ static_dims && continue
-        tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
-        qnew = Expr(ifsym, :(dimm == $n), :(return _nanmean!(B, A, $tc)))
-        for r ∈ m+1:M
-          push!(tc.args, :(dims[$r]))
+    static_dims = Int[]
+    for m ∈ 1:M
+        param = D.parameters[m]
+        if param <: StaticInt
+            new_dim = _dim(param)::Int
+            @assert new_dim ∉ static_dims
+            push!(static_dims, new_dim)
+        else
+            t = Expr(:tuple)
+            for n ∈ static_dims
+                push!(t.args, :(StaticInt{$n}()))
+            end
+            q = Expr(:block, :(dimm = dims[$m]))
+            qold = q
+            ifsym = :if
+            for n ∈ 1:N
+                n ∈ static_dims && continue
+                tc = copy(t)
+                push!(tc.args, :(StaticInt{$n}()))
+                qnew = Expr(ifsym, :(dimm == $n), :(return _nanmean!(B, A, $tc)))
+                for r ∈ m+1:M
+                    push!(tc.args, :(dims[$r]))
+                end
+                push!(qold.args, qnew)
+                qold = qnew
+                ifsym = :elseif
+            end
+            push!(qold.args, Expr(:block, :(throw("Dimension `$dimm` not found."))))
+            return q
         end
-        push!(qold.args, qnew)
-        qold = qnew
-        ifsym = :elseif
-      end
-      push!(qold.args, Expr(:block, :(throw("Dimension `$dimm` not found."))))
-      return q
     end
-  end
-  staticdim_nanmean_quote(static_dims, N)
+    staticdim_nanmean_quote(static_dims, N)
 end
 
 # Efficient @generated in-place mean
 @generated function _nanmean!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
-  N == M && return :(B[1] = _nanmean(A, :); B)
-  branches_nanmean_quote(N, M, D)
+    N == M && return :(B[1] = _nanmean(A, :); B)
+    branches_nanmean_quote(N, M, D)
 end
 
 ## ---

--- a/src/ArrayStats/nansem.jl
+++ b/src/ArrayStats/nansem.jl
@@ -43,7 +43,7 @@ export nansem
 _nansem(μ, corrected::Bool, A, dims::Int) = _nansem(μ, corrected, A, (dims,))
 
 # If the mean isn't known, compute it
-_nansem(::Nothing, corrected::Bool, A, dims::Tuple) = _nansem!(_nanmean(A, dims), corrected, A, dims)
+_nansem(::Nothing, corrected::Bool, A, dims::Tuple) = _nansem!(_nanmean(A, dims, NANMEAN_SIZE_THRESHOLD), corrected, A, dims)
 # Reduce all the dims!
 function _nansem(::Nothing, corrected::Bool, A, ::Colon)
   Tₒ = Base.promote_op(/, eltype(A), Int)

--- a/src/ArrayStats/nanskewness.jl
+++ b/src/ArrayStats/nanskewness.jl
@@ -45,7 +45,7 @@ export nanskewness
 _nanskewness(μ, corrected::Bool, A, dims::Int) = _nanskewness(μ, corrected, A, (dims,))
 
 # If the mean isn't known, compute it
-_nanskewness(::Nothing, corrected::Bool, A, dims::Tuple) = _nanskewness!(_nanmean(A, dims), corrected, A, dims)
+_nanskewness(::Nothing, corrected::Bool, A, dims::Tuple) = _nanskewness!(_nanmean(A, dims, NANMEAN_SIZE_THRESHOLD), corrected, A, dims)
 # Reduce all the dims!
 function _nanskewness(::Nothing, corrected::Bool, A, ::Colon)
     T = eltype(A)

--- a/src/ArrayStats/nansum.jl
+++ b/src/ArrayStats/nansum.jl
@@ -82,108 +82,115 @@ end
 # Generate customized set of loops for a given ndims and a vector
 # `static_dims` of dimensions to reduce over
 function staticdim_nansum_quote(static_dims::Vector{Int}, N::Int)
-  M = length(static_dims)
-  # `static_dims` now contains every dim we're taking the sum over.
-  Bᵥ = Expr(:call, :view, :B)
-  reduct_inds = Int[]
-  nonreduct_inds = Int[]
-  # Firstly, build our expressions for indexing each array
-  Aind = :(A[])
-  Bind = :(Bᵥ[])
-  inds = Vector{Symbol}(undef, N)
-  for n ∈ 1:N
-    ind = Symbol(:i_,n)
-    inds[n] = ind
-    push!(Aind.args, ind)
-    if n ∈ static_dims
-      push!(reduct_inds, n)
-      push!(Bᵥ.args, :(firstindex(B,$n)))
-    else
-      push!(nonreduct_inds, n)
-      push!(Bᵥ.args, :)
-      push!(Bind.args, ind)
+    M = length(static_dims)
+    # `static_dims` now contains every dim we're taking the sum over.
+    Bᵥ = Expr(:call, :view, :B)
+    reduct_inds = Int[]
+    nonreduct_inds = Int[]
+    # Firstly, build our expressions for indexing each array
+    Aind = :(A[])
+    Bind = :(Bᵥ[])
+    inds = Vector{Symbol}(undef, N)
+
+    for n ∈ 1:N
+        ind = Symbol(:i_,n)
+        inds[n] = ind
+        push!(Aind.args, ind)
+        if n ∈ static_dims
+            push!(reduct_inds, n)
+            push!(Bᵥ.args, :(firstindex(B,$n)))
+        else
+            push!(nonreduct_inds, n)
+            push!(Bᵥ.args, :)
+            push!(Bind.args, ind)
+        end
     end
-  end
-  firstn = first(nonreduct_inds)
-  # Secondly, build up our set of loops
-  block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
-  if length(nonreduct_inds) > 1
-    for n ∈ @view(nonreduct_inds[2:end])
-      newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
-      block = newblock
+
+    # Secondly, build up our set of loops
+    firstn = first(nonreduct_inds)
+    block = Expr(:block)
+    loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+    if length(nonreduct_inds) > 1
+        for n ∈ @view(nonreduct_inds[2:end])
+            newblock = Expr(:block)
+            push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+            block = newblock
+        end
     end
-  end
-  rblock = block
-  # Push more things here if you want them at the beginning of the reduction loop
-  push!(rblock.args, :(Σ = ∅))
-  # Build the reduction loop
-  for n ∈ reduct_inds
-    newblock = Expr(:block)
-    if n==last(reduct_inds)
-      push!(block.args, Expr(:macrocall, Symbol("@simd"), :ivdep, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock)))
-    else
-      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
+
+    # Push more things here if you want them at the beginning of the reduction loop
+    rblock = block
+    push!(rblock.args, :(Σ = ∅))
+
+    # Build the reduction loop
+    for n ∈ reduct_inds
+        newblock = Expr(:block)
+        if n==last(reduct_inds)
+            push!(block.args, Expr(:macrocall, Symbol("@simd"), :ivdep, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock)))
+        else
+            push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
+        end
+        block = newblock
     end
-    block = newblock
-  end
-  # Push more things here if you want them in the innermost loop
-  push!(block.args, :(Aᵢ = $Aind))
-  push!(block.args, :(notnan = Aᵢ==Aᵢ))
-  push!(block.args, :(Σ += ifelse(notnan, Aᵢ, ∅)))
-  # Push more things here if you want them at the end of the reduction loop
-  push!(rblock.args, :($Bind = Σ))
-  # Put it all together
-  quote
-    ∅ = zero(eltype(B))
-    Bᵥ = $Bᵥ
-    @inbounds $loops
-    return B
-  end
+
+    # Push more things here if you want them in the innermost loop
+    push!(block.args, :(Aᵢ = $Aind))
+    push!(block.args, :(notnan = Aᵢ==Aᵢ))
+    push!(block.args, :(Σ += ifelse(notnan, Aᵢ, ∅)))
+
+    # Push more things here if you want them at the end of the reduction loop
+    push!(rblock.args, :($Bind = Σ))
+
+    # Put it all together
+    quote
+        ∅ = zero(eltype(B))
+        Bᵥ = $Bᵥ
+        @inbounds $loops
+        return B
+    end
 end
 
 # Turn non-static integers in `dims` tuple into `StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nansum_quote(N::Int, M::Int, D)
-  static_dims = Int[]
-  for m ∈ 1:M
-    param = D.parameters[m]
-    if param <: StaticInt
-      new_dim = _dim(param)::Int
-      @assert new_dim ∉ static_dims
-      push!(static_dims, new_dim)
-    else
-      t = Expr(:tuple)
-      for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
-      end
-      q = Expr(:block, :(dimm = dims[$m]))
-      qold = q
-      ifsym = :if
-      for n ∈ 1:N
-        n ∈ static_dims && continue
-        tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
-        qnew = Expr(ifsym, :(dimm == $n), :(return _nansum!(B, A, $tc)))
-        for r ∈ m+1:M
-          push!(tc.args, :(dims[$r]))
+    static_dims = Int[]
+    for m ∈ 1:M
+        param = D.parameters[m]
+        if param <: StaticInt
+            new_dim = _dim(param)::Int
+            @assert new_dim ∉ static_dims
+            push!(static_dims, new_dim)
+        else
+            t = Expr(:tuple)
+            for n ∈ static_dims
+                push!(t.args, :(StaticInt{$n}()))
+            end
+            q = Expr(:block, :(dimm = dims[$m]))
+            qold = q
+            ifsym = :if
+            for n ∈ 1:N
+                n ∈ static_dims && continue
+                tc = copy(t)
+                push!(tc.args, :(StaticInt{$n}()))
+                qnew = Expr(ifsym, :(dimm == $n), :(return _nansum!(B, A, $tc)))
+                for r ∈ m+1:M
+                    push!(tc.args, :(dims[$r]))
+                end
+                push!(qold.args, qnew)
+                qold = qnew
+                ifsym = :elseif
+            end
+            push!(qold.args, Expr(:block, :(throw("Dimension `$dimm` not found."))))
+            return q
         end
-        push!(qold.args, qnew)
-        qold = qnew
-        ifsym = :elseif
-      end
-      push!(qold.args, Expr(:block, :(throw("Dimension `$dimm` not found."))))
-      return q
     end
-  end
-  staticdim_nansum_quote(static_dims, N)
+    staticdim_nansum_quote(static_dims, N)
 end
 
 # Efficient @generated in-place sum
 @generated function _nansum!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
-  N == M && return :(B[1] = _nansum(A, :); B)
-  branches_nansum_quote(N, M, D)
+    N == M && return :(B[1] = _nansum(A, :); B)
+    branches_nansum_quote(N, M, D)
 end
 
 

--- a/src/ArrayStats/nansum.jl
+++ b/src/ArrayStats/nansum.jl
@@ -106,6 +106,11 @@ function staticdim_nansum_quote(static_dims::Vector{Int}, N::Int)
         end
     end
 
+    # Reverse the axis lists so that we build up the loops from slow-axis to
+    # fast-axis for column major arrays.
+    reverse!(nonreduct_inds)
+    reverse!(reduct_inds)
+
     # Secondly, build up our set of loops
     firstn = first(nonreduct_inds)
     block = Expr(:block)

--- a/src/ArrayStats/nanvar.jl
+++ b/src/ArrayStats/nanvar.jl
@@ -43,7 +43,7 @@ export nanvar
 _nanvar(μ, corrected::Bool, A, dims::Int) = _nanvar(μ, corrected, A, (dims,))
 
 # If the mean isn't known, compute it
-_nanvar(::Nothing, corrected::Bool, A, dims::Tuple) = _nanvar!(_nanmean(A, dims), corrected, A, dims)
+_nanvar(::Nothing, corrected::Bool, A, dims::Tuple) = _nanvar!(_nanmean(A, dims, NANMEAN_SIZE_THRESHOLD), corrected, A, dims)
 # Reduce all the dims!
 function _nanvar(::Nothing, corrected::Bool, A, ::Colon)
     Tₘ = Base.promote_op(/, eltype(A), Int)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Hwloc = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 module BaseTest
-    using Test, NaNStatistics, StatsBase, Statistics, LinearAlgebra, Distributions
+    using Test, NaNStatistics, StatsBase, Statistics, LinearAlgebra, Distributions, Hwloc
 
     @testset "ArrayStats" begin include("testArrayStats.jl") end
     @testset "Covariance and Correlation" begin include("testCovCor.jl") end

--- a/test/testArrayStats.jl
+++ b/test/testArrayStats.jl
@@ -419,6 +419,22 @@
     @test vec(nankurtosis(A, dims=1)) ≈ kurtosis.(eachcol(A))
     @test vec(nankurtosis(A, dims=2)) ≈ kurtosis.(eachrow(A))
 
+## --- Test the correctness of the mapreduce implementations of nansum/nanmean
+
+    A = rand(100, 100)
+    for i in rand(eachindex(A), 100)
+        A[i] = NaN
+    end
+
+    generated_func_nanmean = nanmean(A; dims=2, size_threshold=typemax(Int))
+    mapreduce_nanmean = nanmean(A; dims=2, size_threshold=0)
+    # If the values are completely identical then we're likely testing the same implementation
+    @test sum(mapreduce_nanmean .- generated_func_nanmean) != 0
+    @test generated_func_nanmean ≈ mapreduce_nanmean
+
+    A = rand(100, 100)
+    @test sum(A; dims=2) ≈ nansum(A; dims=2)
+
 ## --- Test fallbacks for complex reductions
 
     A = randn((2 .+ (1:6))...);


### PR DESCRIPTION
This implements some of the things described in #54, namely implementations for nanmean/nansum using patterns from Base. The changes to the loop ordering in 1e8c7c8 could be applied to the other functions too but I was lazy :sloth: I think it'd be good if we could reduce the amount of code duplication in the future.

The changes unfortunately ended up being a lot more invasive than I hoped because of the extra `size_threshold` argument (naming is up for debate). I added some benchmarks as well (smaller is better for all columns):

<details>
<summary>AMD Epyc server</summary>

|                            | dirty            | main             | dirty / main  |
|:---------------------------|:----------------:|:----------------:|:-------------:|
| nanmean/big array, dim 1   | 2.92 ± 0.044 ms  | 2.98 ± 0.049 ms  | 0.979 ± 0.022 |
| nanmean/big array, dim 2   | 11.1 ± 0.037 ms  | 13.1 ± 0.8 ms    | 0.844 ± 0.051 |
| nanmean/big array, dim 3   | 14.4 ± 3.5 ms    | 18.2 ± 0.91 ms   | 0.792 ± 0.2   |
| nanmean/small array, dim 1 | 0.59 ± 0.011 μs  | 0.6 ± 0.01 μs    | 0.983 ± 0.025 |
| nanmean/small array, dim 2 | 0.97 ± 0.01 μs   | 0.98 ± 0.01 μs   | 0.99 ± 0.014  |
| nanmean/small array, dim 3 | 0.77 ± 0.01 μs   | 0.87 ± 0.002 μs  | 0.885 ± 0.012 |
| nanmean/small vector       | 31 ± 10 ns       | 30 ± 1 ns        | 1.03 ± 0.34   |
| nansum/big array, dim 1    | 2.75 ± 0.062 ms  | 2.83 ± 0.05 ms   | 0.972 ± 0.028 |
| nansum/big array, dim 2    | 2.82 ± 0.045 ms  | 10 ± 0.44 ms     | 0.282 ± 0.013 |
| nansum/big array, dim 3    | 3.26 ± 0.51 ms   | 18.6 ± 0.7 ms    | 0.175 ± 0.028 |
| nansum/small array, dim 1  | 0.589 ± 0.01 μs  | 0.54 ± 0.011 μs  | 1.09 ± 0.029  |
| nansum/small array, dim 2  | 0.551 ± 0.01 μs  | 0.611 ± 0.02 μs  | 0.902 ± 0.034 |
| nansum/small array, dim 3  | 0.53 ± 0.05 μs   | 0.72 ± 0.019 μs  | 0.736 ± 0.072 |
| nansum/small vector        | 30 ± 0 ns        | 30 ± 0 ns        | 1 ± 0         |
| time_to_load               | 0.189 ± 0.0022 s | 0.189 ± 0.0032 s | 1 ± 0.021     |

</details>

<details>
<summary>Intel server</summary>

|                            | dirty            | main               | dirty / main   |
|:---------------------------|:----------------:|:------------------:|:--------------:|
| nanmean/big array, dim 1   | 9.5 ± 0.6 ms     | 8.79 ± 0.51 ms     | 1.08 ± 0.093   |
| nanmean/big array, dim 2   | 14.2 ± 0.26 ms   | 0.0332 ± 8.9e-05 s | 0.429 ± 0.0078 |
| nanmean/big array, dim 3   | 21.4 ± 4.3 ms    | 0.0362 ± 0.0019 s  | 0.591 ± 0.12   |
| nanmean/small array, dim 1 | 1.27 ± 0.053 μs  | 1.3 ± 0.019 μs     | 0.975 ± 0.043  |
| nanmean/small array, dim 2 | 1.62 ± 0.017 μs  | 1.68 ± 0.017 μs    | 0.964 ± 0.014  |
| nanmean/small array, dim 3 | 1.5 ± 0.033 μs   | 1.44 ± 0.015 μs    | 1.04 ± 0.025   |
| nanmean/small vector       | 0.049 ± 0.003 μs | 0.051 ± 0.004 μs   | 0.961 ± 0.096  |
| nansum/big array, dim 1    | 8.4 ± 0.54 ms    | 8.02 ± 0.6 ms      | 1.05 ± 0.1     |
| nansum/big array, dim 2    | 8.35 ± 0.23 ms   | 25.6 ± 0.086 ms    | 0.326 ± 0.009  |
| nansum/big array, dim 3    | 13.8 ± 1.1 ms    | 24 ± 1.8 ms        | 0.573 ± 0.063  |
| nansum/small array, dim 1  | 0.911 ± 0.031 μs | 1.05 ± 0.006 μs    | 0.871 ± 0.03   |
| nansum/small array, dim 2  | 1.01 ± 0.071 μs  | 1.22 ± 0.019 μs    | 0.825 ± 0.06   |
| nansum/small array, dim 3  | 1.05 ± 0.12 μs   | 0.965 ± 0.007 μs   | 1.09 ± 0.13    |
| nansum/small vector        | 0.046 ± 0.001 μs | 0.044 ± 0.004 μs   | 1.05 ± 0.098   |
| time_to_load               | 0.258 ± 0.015 s  | 0.264 ± 0.0094 s   | 0.976 ± 0.068  |

</details>

<details>
<summary>Intel laptop</summary>

Nansum improvements are weirdly massive here for some reason.

|                            | dirty            | main               | dirty / main   |
|:---------------------------|:----------------:|:------------------:|:--------------:|
| nanmean/big array, dim 1   | 4.74 ± 0.051 ms  | 4.83 ± 0.043 ms    | 0.981 ± 0.014  |
| nanmean/big array, dim 2   | 10.2 ± 0.045 ms  | 0.0493 ± 0.00095 s | 0.208 ± 0.0041 |
| nanmean/big array, dim 3   | 14.3 ± 3.1 ms    | 0.0564 ± 0.002 s   | 0.254 ± 0.056  |
| nanmean/small array, dim 1 | 0.736 ± 0.081 μs | 0.768 ± 0.057 μs   | 0.958 ± 0.13   |
| nanmean/small array, dim 2 | 1.48 ± 0.14 μs   | 1.6 ± 0.21 μs      | 0.922 ± 0.15   |
| nanmean/small array, dim 3 | 1.64 ± 0.16 μs   | 1.69 ± 0.17 μs     | 0.965 ± 0.13   |
| nanmean/small vector       | 0.04 ± 0.003 μs  | 0.046 ± 0.002 μs   | 0.87 ± 0.075   |
| nansum/big array, dim 1    | 4.32 ± 0.07 ms   | 4.4 ± 0.061 ms     | 0.981 ± 0.021  |
| nansum/big array, dim 2    | 4.59 ± 0.07 ms   | 0.045 ± 0.00011 s  | 0.102 ± 0.0016 |
| nansum/big array, dim 3    | 9.23 ± 0.7 ms    | 0.0572 ± 0.0014 s  | 0.161 ± 0.013  |
| nansum/small array, dim 1  | 0.858 ± 0.074 μs | 0.959 ± 0.11 μs    | 0.895 ± 0.13   |
| nansum/small array, dim 2  | 0.937 ± 0.075 μs | 1.15 ± 0.11 μs     | 0.813 ± 0.1    |
| nansum/small array, dim 3  | 0.867 ± 0.073 μs | 1.26 ± 0.12 μs     | 0.687 ± 0.086  |
| nansum/small vector        | 0.04 ± 0.001 μs  | 0.043 ± 0.001 μs   | 0.93 ± 0.032   |
| time_to_load               | 0.154 ± 0.0079 s | 0.16 ± 0.0086 s    | 0.962 ± 0.071  |

</details>

I've tried to keep all the commits atomic so I'd recommend reviewing them one-by-one.

EDIT: two issues in CI:
- Something is very wrong on 32bit, maybe an overflow somewhere.
- ~~On nightly there's a nan in the output :grimacing:~~ Dumb mistake, fixed in 4fca8ce.