### PR TITLE
Implement nanmean!() and nansum!()

### DIFF
--- a/src/ArrayStats/ArrayStats.jl
+++ b/src/ArrayStats/ArrayStats.jl
@@ -610,4 +610,19 @@ macro _mapreduce_impl(B, A, expr)
     end |> esc
 end
 
+function _reduced_size(A::AbstractArray{T, N}, dims::Tuple) where {T, N}
+    sᵢ = size(A)
+    ntuple(Val{N}()) do d
+        ifelse(d ∈ dims, 1, sᵢ[d])
+    end
+end
+
+function _normalize_dims(dims)
+    if dims isa Integer
+        (dims,)
+    else
+        dims
+    end
+end
+
 ## --- End of File

--- a/src/ArrayStats/nanmean.jl
+++ b/src/ArrayStats/nanmean.jl
@@ -240,7 +240,7 @@ function branches_nanmean_quote(N::Int, M::Int, D, st)
                 n ∈ static_dims && continue
                 tc = copy(t)
                 push!(tc.args, :(StaticInt{$n}()))
-                qnew = Expr(ifsym, :(dimm == $n), :(return _nanmean!(B, A, $tc, $st)))
+                qnew = Expr(ifsym, :(dimm == $n), :(return _nanmean!(B, A, $tc, st)))
                 for r ∈ m+1:M
                     push!(tc.args, :(dims[$r]))
                 end

--- a/test/testDimensionalDataExt.jl
+++ b/test/testDimensionalDataExt.jl
@@ -30,10 +30,14 @@ res::DimArray = DimArray([1], :foo)
     res = nanstd(x, x; dims=:foo)
     @test res == nanstd(parent(x), parent(x); dims=1)
 
+    res = zeros(Dim{:bar}(size(x, :bar)))
+
     # Since all the reduction functions use the same machinery we only do sanity
     # checks for the other ones.
     @test nanmean(x; dim=:foo) isa DimArray
+    @test nanmean!(res, x; dim=:foo) isa DimArray
     @test nansum(x; dim=:foo) isa DimArray
+    @test nansum!(res, x; dim=:foo) isa DimArray
     @test nanstd(x; dim=:foo) isa DimArray
     @test nanvar(x; dim=:foo) isa DimArray
     @test nanaad(x; dim=:foo) isa DimArray


### PR DESCRIPTION
I also sneaked in a bugfix in d9cd0af. I went with a slightly different implementation style than the existing functions, with less reliance on dispatch and more reliance on the compiler to infer things correctly. I also added a few helper functions to `ArrayStats.jl` to try to reduce duplication.

Here's some benchmarks on 1.11 using both `dim` and `dims` for `nanmean!` and `nanmean`:
```julia-repl
julia> x = ones(10, 10, 10);                                                                                                                                                                                                                   
                                                                                                                                                                                                                                               
julia> out = rand(10, 10);                                                                                                                                                                                                                     
                                                                                                                                                                                                                                               
julia> @benchmark nanmean!($out, $x; dims=1)                                                                                                                                                                                                   
BenchmarkTools.Trial: 10000 samples with 196 evaluations per sample.                                                                                                                                                                           
 Range (min … max):  464.281 ns …   7.880 μs  ┊ GC (min … max): 0.00% … 0.00%                                                                                                                                                                  
 Time  (median):     483.898 ns               ┊ GC (median):    0.00%                                                                                                                                                                          
 Time  (mean ± σ):   498.849 ns ± 109.806 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%                                                                                                                                                                  
                                                                                                                                                                                                                                               
  ▁  ▁█▂ ▅▇▅▅▃▃▃▁▁ ▁            ▁    ▁▂    ▁▁    ▁▄      ▁      ▂                                                                                                                                                                              
  █▃▄███▆█████████████▇▆▆▆▇▅▅▂▃██▆▃▄▆██▇▅▅▅██▅▅▆▅██▇▄▅█▅██▃▄▃▅▅ █                                                                                                                                                                              
  464 ns        Histogram: log(frequency) by time        611 ns <                                                                                                                                                                              
                                                                                                                                                                                                                                               
 Memory estimate: 48 bytes, allocs estimate: 1.                                                                                                                                                                                                
                                                                                                                                                                                                                                               
julia> @benchmark nanmean!($out, $x; dim=1)
BenchmarkTools.Trial: 10000 samples with 188 evaluations per sample.
 Range (min … max):  475.649 ns …  49.776 μs  ┊ GC (min … max): 0.00% … 98.67%
 Time  (median):     522.574 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   551.480 ns ± 540.397 ns  ┊ GC (mean ± σ):  1.44% ±  1.68%

    █▆                           ▁                                
  ▂▁██▂▄▂▃▄▅▃▂▂▁▁▁▁▁▁▁▁▁▂▁▁▁▃▂▃▃▃██▅▅▃▂▂▂▂▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  476 ns           Histogram: frequency by time          686 ns <

 Memory estimate: 96 bytes, allocs estimate: 2.

julia> @benchmark nanmean($x; dims=1)
BenchmarkTools.Trial: 10000 samples with 183 evaluations per sample.
 Range (min … max):  483.202 ns …  46.168 μs  ┊ GC (min … max): 0.00% … 97.77%
 Time  (median):     556.631 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   611.579 ns ± 631.964 ns  ┊ GC (mean ± σ):  8.18% ±  9.28%

  ▆█▃▂▁▁▃                                                       ▁
  ███████▆▄▅▃▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆ █
  483 ns        Histogram: log(frequency) by time       4.09 μs <

 Memory estimate: 944 bytes, allocs estimate: 2.

julia> @benchmark nanmean($x; dim=1)
BenchmarkTools.Trial: 10000 samples with 179 evaluations per sample.
 Range (min … max):  481.838 ns … 115.348 μs  ┊ GC (min … max): 0.00% … 98.90%
 Time  (median):     586.936 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   696.124 ns ±   1.771 μs  ┊ GC (mean ± σ):  8.68% ±  6.33%

  ▄▆    █ ▁                                                       
  ██▄▄▂▃█▇█▆▃▂▂▂▃▂▂▂▂▂▂▃▅█▆▅▅▄▃▃▂▂▂▂▂▂▁▂▂▁▁▁▁▁▁▂▁▁▂▁▁▁▁▂▁▁▁▂▁▁▂ ▃
  482 ns           Histogram: frequency by time         1.33 μs <

 Memory estimate: 992 bytes, allocs estimate: 3.
```

The main takeaway is that in both cases the number of allocations in `nanmean!` drops by exactly 1 compared to `nanmean`, which I think means that the compiler is able to optimize the less dispatch-y `nanmean!` implementation to an equivalent form of the more dispatch-y `nanmean` implementation.