### PR TITLE
Ensure that `_nanmean_mapreduce!` inserts nans for zero counts

### DIFF
--- a/src/ArrayStats/nanmean.jl
+++ b/src/ArrayStats/nanmean.jl
@@ -124,10 +124,10 @@ function _nanmean_mapreduce_impl!(B, A, counts)
                          counts[ir, IR] += 1
                      end)
 
-    ∅ = zero(eltype(B))
+    nan_value = convert(eltype(B), NaN)
     @inbounds for i in eachindex(B)
         if iszero(counts[i])
-            B[i] = ∅
+            B[i] = nan_value
         else
             B[i] /= counts[i]
         end

--- a/test/testArrayStats.jl
+++ b/test/testArrayStats.jl
@@ -432,8 +432,23 @@
     @test sum(mapreduce_nanmean .- generated_func_nanmean) != 0
     @test generated_func_nanmean ≈ mapreduce_nanmean
 
+    # Test that dimensions full of nans are handled correctly (all nans)
+    fill!(A, NaN)
+    @test all(isnan.(nanmean(A; dims=2, size_threshold=0)))
+
+    # Sanity tests for nansum
     A = rand(100, 100)
     @test sum(A; dims=2) ≈ nansum(A; dims=2)
+
+    A = ones(100, 100)
+    A[:, 1] .= NaN
+    A[1, :] .= NaN
+    @test nansum(A; dim=1) ≈ nansum(A; dim=2)
+
+    # Test that dimensions full of nans are handled the same as
+    # `_nansum_generated!` (all zeros).
+    fill!(A, NaN)
+    @test nansum(A; dim=1) == nansum(A; dim=2)
 
 ## --- Test fallbacks for complex reductions
 


### PR DESCRIPTION
Also added some more tests for `nansum`. In doing so I noticed that `nansum` will always give 0 instead of nan, which always annoyed me in numpy :stuck_out_tongue: Maybe we could change that in a later version? It'd be breaking though, and if people expect that behaviour then we'd need a way to opt in/out.

Fixes #59.