### PR TITLE
Allocation helpers and `movmean!()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ See also [JuliaSIMD/VectorizedStatistics.jl](https://github.com/JuliaSIMD/Vector
 Summary statistics exported by NaNStatistics are generally named the same as their normal counterparts, but with "nan" in front of the name, similar to the Matlab and NumPy conventions. Options include:
 ##### Reductions
 * `nansum`
+* `nansum!`
 * `nanminimum`
 * `nanmaximum`
 * `nanextrema`
 
 ##### Measures of central tendency
 * `nanmean` &emsp; arithmetic mean, ignoring `NaN`s
+* `nanmean!`&emsp; as `nanmean`, but writes to a given output array
 * `nanmedian` &emsp; median, ignoring `NaN`s
 * `nanmedian!` &emsp; as `nanmedian` but quicksorts in-place for efficiency
 
@@ -147,6 +149,14 @@ julia> movmean(A, 3)
 
  * `nanstandardize` / `nanstandardize!`
  De-mean and set to unit variance
+
+### Allocation functions
+To use mutating functions like `nanmean!` you can call the appropriate
+allocation function and get back an array that can be passed as the output
+argument.
+
+* `allocate_nanmean`
+* `allocate_nansum`
 
 ### DimensionalData support
 Almost all functions support

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ julia> @btime nanbinmean($x,$y,xmin,xmax,nbins)
  90.30275863080671
 ```
 ### Other functions
-* `movmean`
+* `movmean` / `movmean!`
 A simple moving average function, which can operate in 1D or 2D, ignoring NaNs.
 ```
 julia> A = rand(1:10, 4,4)
@@ -157,6 +157,7 @@ argument.
 
 * `allocate_nanmean`
 * `allocate_nansum`
+* `allocate_movmean`
 
 ### DimensionalData support
 Almost all functions support

--- a/ext/NaNStatisticsDimensionalDataExt.jl
+++ b/ext/NaNStatisticsDimensionalDataExt.jl
@@ -78,4 +78,8 @@ function NaNStatistics.movmean(A::DD.AbstractDimVecOrMat, n::Number)
     rebuild(A, data)
 end
 
+function NaNStatistics._allocate_reduce(Tₒ, A::AbstractDimArray, dims)
+    rebuild(A, NaNStatistics._allocate_reduce(Tₒ, parent(A), dims), DD.reducedims(A, dims))
+end
+
 end

--- a/src/ArrayStats/ArrayStats.jl
+++ b/src/ArrayStats/ArrayStats.jl
@@ -625,4 +625,10 @@ function _normalize_dims(dims)
     end
 end
 
+function _allocate_reduce(Tₒ, A, dims)
+    output_size = _normalize_dims(dims)
+    sₒ = _reduced_size(A, output_size)
+    similar(A, Tₒ, sₒ)
+end
+
 ## --- End of File

--- a/test/testArrayStats.jl
+++ b/test/testArrayStats.jl
@@ -570,5 +570,11 @@
     @test nanmedian(x, dim=(1, 3)) == ones(100)
     @test nanmedian(x, dim=(1, 2, 3)) == fill(1.0)
 
+## --- Allocation functions
+
+    @test size(NaNStatistics.allocate_nanmean(rand(10, 10), 1)) == (1, 10)
+    @test NaNStatistics.allocate_nanmean(rand(Float32, 10, 10), 1) isa Matrix{Float32}
+    @test NaNStatistics.allocate_nansum(rand(10, 10), 1) isa Matrix{Float64}
+    @test NaNStatistics.allocate_nansum(rand(Int, 10, 10), 1) isa Matrix{Int}
 
 ## --- End of File

--- a/test/testArrayStats.jl
+++ b/test/testArrayStats.jl
@@ -576,5 +576,6 @@
     @test NaNStatistics.allocate_nanmean(rand(Float32, 10, 10), 1) isa Matrix{Float32}
     @test NaNStatistics.allocate_nansum(rand(10, 10), 1) isa Matrix{Float64}
     @test NaNStatistics.allocate_nansum(rand(Int, 10, 10), 1) isa Matrix{Int}
+    @test NaNStatistics.allocate_movmean(rand(10)) isa Vector{Float64}
 
 ## --- End of File

--- a/test/testDimensionalDataExt.jl
+++ b/test/testDimensionalDataExt.jl
@@ -89,3 +89,14 @@ end
     res = nanrange(x; dim=:foo)
     @test res == nanrange(parent(x); dim=1)
 end
+
+@testset "Allocation helpers" begin
+    data = rand(X(5), Y(11:15))
+
+    # Just test allocate_nanmean() since the other reduction allocators all go
+    # through _allocate_reduce().
+    out = NaNStatistics.allocate_nanmean(data, 1)
+    @test size(out) == (1, 5)
+    @test out isa DimMatrix{Float64}
+    @test lookup(out, Y) == lookup(data, Y)
+end

--- a/test/testDimensionalDataExt.jl
+++ b/test/testDimensionalDataExt.jl
@@ -99,4 +99,9 @@ end
     @test size(out) == (1, 5)
     @test out isa DimMatrix{Float64}
     @test lookup(out, Y) == lookup(data, Y)
+
+    # Test allocate_movmean() explicitly since it doesn't go through _allocate_reduce()
+    out = NaNStatistics.allocate_movmean(data)
+    @test size(out) == size(data)
+    @test out isa DimMatrix{Float64}
 end


### PR DESCRIPTION
This adds some helper functions to allocate outputs for mutating functions, and a mutating version of `movmean()`.