### PR TITLE
Drop Static and StaticArrayInterface deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,6 @@ version = "0.6.56"
 
 [deps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"
 
 [weakdeps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
@@ -22,7 +20,5 @@ NaNStatisticsUnitfulExt = "Unitful"
 DimensionalData = "0.29, 0.30"
 Hwloc = "3.3"
 PrecompileTools = "1"
-Static = "0.8, 1"
-StaticArrayInterface = "1"
 Unitful = "1"
 julia = "1.10"

--- a/src/ArrayStats/nancumsum.jl
+++ b/src/ArrayStats/nancumsum.jl
@@ -128,11 +128,11 @@ function staticdim_nancumsum_quote(static_dims::Vector{Int}, N::Int)
   firstn = first(nonreduct_inds)
   # Secondly, build up our set of loops
   block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+  loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
   if length(nonreduct_inds) > 1
     for n ∈ @view(nonreduct_inds[2:end])
       newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
       block = newblock
     end
   end
@@ -161,20 +161,20 @@ function staticdim_nancumsum_quote(static_dims::Vector{Int}, N::Int)
 end
 
 # Chris Elrod metaprogramming magic:
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nancumsum_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -182,7 +182,7 @@ function branches_nancumsum_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nancumsum!(B, A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -199,7 +199,7 @@ function branches_nancumsum_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place sum
-@generated function _nancumsum!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nancumsum!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   N == M && return _nancumsum!(B, A, :)
   branches_nancumsum_quote(N, M, D)
 end
@@ -223,11 +223,11 @@ function staticdim_nancumsum!_quote(static_dims::Vector{Int}, N::Int)
   firstn = first(nonreduct_inds)
   # Secondly, build up our set of loops
   block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices(A,$firstn)), block)
+  loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
   if length(nonreduct_inds) > 1
     for n ∈ @view(nonreduct_inds[2:end])
       newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices(A,$n)), newblock))
+      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
       block = newblock
     end
   end
@@ -259,14 +259,14 @@ function branches_nancumsum!_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -274,7 +274,7 @@ function branches_nancumsum!_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nancumsum!(A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -291,7 +291,7 @@ function branches_nancumsum!_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place sum
-@generated function _nancumsum!(A::AbstractArray{T,N}, dims::D) where {T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nancumsum!(A::AbstractArray{T,N}, dims::D) where {T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   N == M && return _nancumsum!(A, :)
   branches_nancumsum!_quote(N, M, D)
 end

--- a/src/ArrayStats/nankurtosis.jl
+++ b/src/ArrayStats/nankurtosis.jl
@@ -157,11 +157,11 @@ function staticdim_nankurtosis_quote(static_dims::Vector{Int}, N::Int)
   firstn = first(nonreduct_inds)
   # Secondly, build up our set of loops
   block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+  loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
   if length(nonreduct_inds) > 1
     for n ∈ @view(nonreduct_inds[2:end])
       newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
       block = newblock
     end
   end
@@ -201,20 +201,20 @@ function staticdim_nankurtosis_quote(static_dims::Vector{Int}, N::Int)
   end
 end
 
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nankurtosis_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -222,7 +222,7 @@ function branches_nankurtosis_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nankurtosis!(B, corrected, A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -239,7 +239,7 @@ function branches_nankurtosis_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place var
-@generated function _nankurtosis!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nankurtosis!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   N == M && return :(B[1] = _nankurtosis(B[1], corrected, A, :); B)
   branches_nankurtosis_quote(N, M, D)
 end

--- a/src/ArrayStats/nanlogsumexp.jl
+++ b/src/ArrayStats/nanlogsumexp.jl
@@ -32,10 +32,10 @@ As `nancumsum`, but operating on logarithms; as `nanlogsumexp`, but returning a 
 ```julia
 ```
 """
-nanlogcumsumexp(A; reverse=false) = _nanlogcumsumexp(A, static(reverse))
+nanlogcumsumexp(A; reverse=false) = _nanlogcumsumexp(A, _static(reverse))
 export nanlogcumsumexp
 
-function _nanlogcumsumexp(A, ::False)
+function _nanlogcumsumexp(A, ::_False)
     Tᵣ = Base.promote_op(exp, eltype(A))
     Σ = ∅ = zero(Tᵣ)
     lΣ = fill!(similar(A, Tᵣ), ∅)
@@ -59,7 +59,7 @@ function _nanlogcumsumexp(A, ::False)
     end
     return lΣ
 end
-function _nanlogcumsumexp(A, ::True)
+function _nanlogcumsumexp(A, ::_True)
     Tᵣ = Base.promote_op(exp, eltype(A))
     Σ = ∅ = zero(Tᵣ)
     lΣ = fill!(similar(A, Tᵣ), ∅)

--- a/src/ArrayStats/nanmean.jl
+++ b/src/ArrayStats/nanmean.jl
@@ -208,11 +208,11 @@ function staticdim_nanmean_quote(static_dims::Vector{Int}, N::Int)
     # Secondly, build up our set of loops
     firstn = first(nonreduct_inds)
     block = Expr(:block)
-    loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+    loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
     if length(nonreduct_inds) > 1
         for n ∈ @view(nonreduct_inds[2:end])
             newblock = Expr(:block)
-            push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+            push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
             block = newblock
         end
     end
@@ -250,20 +250,20 @@ function staticdim_nanmean_quote(static_dims::Vector{Int}, N::Int)
     end
 end
 
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nanmean_quote(N::Int, M::Int, D, st)
     static_dims = Int[]
     for m ∈ 1:M
         param = D.parameters[m]
-        if param <: StaticInt
+        if param <: _StaticInt
             new_dim = _dim(param)::Int
             @assert new_dim ∉ static_dims
             push!(static_dims, new_dim)
         else
             t = Expr(:tuple)
             for n ∈ static_dims
-                push!(t.args, :(StaticInt{$n}()))
+                push!(t.args, :(_StaticInt{$n}()))
             end
             q = Expr(:block, :(dimm = dims[$m]))
             qold = q
@@ -271,7 +271,7 @@ function branches_nanmean_quote(N::Int, M::Int, D, st)
             for n ∈ 1:N
                 n ∈ static_dims && continue
                 tc = copy(t)
-                push!(tc.args, :(StaticInt{$n}()))
+                push!(tc.args, :(_StaticInt{$n}()))
                 qnew = Expr(ifsym, :(dimm == $n), :(return _nanmean!(B, A, $tc, st)))
                 for r ∈ m+1:M
                     push!(tc.args, :(dims[$r]))
@@ -288,7 +288,7 @@ function branches_nanmean_quote(N::Int, M::Int, D, st)
 end
 
 # Efficient @generated in-place mean
-@generated function _nanmean_generated!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D, st) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nanmean_generated!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D, st) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
     N == M && return :(B[1] = _nanmean(A, :, st); B)
     branches_nanmean_quote(N, M, D, st)
 end

--- a/src/ArrayStats/nansem.jl
+++ b/src/ArrayStats/nansem.jl
@@ -138,11 +138,11 @@ function staticdim_nansem_quote(static_dims::Vector{Int}, N::Int)
   firstn = first(nonreduct_inds)
   # Secondly, build up our set of loops
   block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+  loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
   if length(nonreduct_inds) > 1
     for n ∈ @view(nonreduct_inds[2:end])
       newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
       block = newblock
     end
   end
@@ -178,14 +178,14 @@ function branches_nansem_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -193,7 +193,7 @@ function branches_nansem_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nansem!(B, corrected, A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -210,7 +210,7 @@ function branches_nansem_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place var
-@generated function _nansem!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nansem!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   N == M && return :(B[1] = _nansem(B[1], corrected, A, :); B)
   # total_combinations = binomial(N,M)
   # if total_combinations > 6

--- a/src/ArrayStats/nanskewness.jl
+++ b/src/ArrayStats/nanskewness.jl
@@ -155,11 +155,11 @@ function staticdim_nanskewness_quote(static_dims::Vector{Int}, N::Int)
   firstn = first(nonreduct_inds)
   # Secondly, build up our set of loops
   block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+  loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
   if length(nonreduct_inds) > 1
     for n ∈ @view(nonreduct_inds[2:end])
       newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
       block = newblock
     end
   end
@@ -199,20 +199,20 @@ function staticdim_nanskewness_quote(static_dims::Vector{Int}, N::Int)
   end
 end
 
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nanskewness_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -220,7 +220,7 @@ function branches_nanskewness_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nanskewness!(B, corrected, A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -237,7 +237,7 @@ function branches_nanskewness_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place var
-@generated function _nanskewness!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nanskewness!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   N == M && return :(B[1] = _nanskewness(B[1], corrected, A, :); B)
   branches_nanskewness_quote(N, M, D)
 end

--- a/src/ArrayStats/nansum.jl
+++ b/src/ArrayStats/nansum.jl
@@ -143,11 +143,11 @@ function staticdim_nansum_quote(static_dims::Vector{Int}, N::Int)
     # Secondly, build up our set of loops
     firstn = first(nonreduct_inds)
     block = Expr(:block)
-    loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+    loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
     if length(nonreduct_inds) > 1
         for n ∈ @view(nonreduct_inds[2:end])
             newblock = Expr(:block)
-            push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+            push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
             block = newblock
         end
     end
@@ -184,20 +184,20 @@ function staticdim_nansum_quote(static_dims::Vector{Int}, N::Int)
     end
 end
 
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nansum_quote(N::Int, M::Int, D)
     static_dims = Int[]
     for m ∈ 1:M
         param = D.parameters[m]
-        if param <: StaticInt
+        if param <: _StaticInt
             new_dim = _dim(param)::Int
             @assert new_dim ∉ static_dims
             push!(static_dims, new_dim)
         else
             t = Expr(:tuple)
             for n ∈ static_dims
-                push!(t.args, :(StaticInt{$n}()))
+                push!(t.args, :(_StaticInt{$n}()))
             end
             q = Expr(:block, :(dimm = dims[$m]))
             qold = q
@@ -205,7 +205,7 @@ function branches_nansum_quote(N::Int, M::Int, D)
             for n ∈ 1:N
                 n ∈ static_dims && continue
                 tc = copy(t)
-                push!(tc.args, :(StaticInt{$n}()))
+                push!(tc.args, :(_StaticInt{$n}()))
                 qnew = Expr(ifsym, :(dimm == $n), :(return _nansum!(B, A, $tc)))
                 for r ∈ m+1:M
                     push!(tc.args, :(dims[$r]))
@@ -222,7 +222,7 @@ function branches_nansum_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place sum
-@generated function _nansum_generated!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nansum_generated!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
     N == M && return :(B[1] = _nansum(A, :); B)
     branches_nansum_quote(N, M, D)
 end

--- a/src/ArrayStats/nanvar.jl
+++ b/src/ArrayStats/nanvar.jl
@@ -144,11 +144,11 @@ function staticdim_nanvar_quote(static_dims::Vector{Int}, N::Int)
   firstn = first(nonreduct_inds)
   # Secondly, build up our set of loops
   block = Expr(:block)
-  loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+  loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
   if length(nonreduct_inds) > 1
     for n ∈ @view(nonreduct_inds[2:end])
       newblock = Expr(:block)
-      push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+      push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
       block = newblock
     end
   end
@@ -184,20 +184,20 @@ function staticdim_nanvar_quote(static_dims::Vector{Int}, N::Int)
   end
 end
 
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_nanvar_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -205,7 +205,7 @@ function branches_nanvar_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nanvar!(B, corrected, A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -222,7 +222,7 @@ function branches_nanvar_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place var
-@generated function _nanvar!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nanvar!(B::AbstractArray{Tₒ,N}, corrected::Bool, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   N == M && return :(B[1] = _nanvar(B[1], corrected, A, :); B)
   # total_combinations = binomial(N,M)
   # if total_combinations > 6

--- a/src/NaNStatistics.jl
+++ b/src/NaNStatistics.jl
@@ -1,10 +1,13 @@
 module NaNStatistics
 
-    using Static
-    const IntOrStaticInt = Union{Integer, StaticInt}
-    _dim(::Type{StaticInt{N}}) where {N} = N::Int
+    struct _StaticInt{N} end
+    _StaticInt(N::Int) = _StaticInt{N}()
+    const _IntOrStaticInt = Union{Integer, _StaticInt}
+    _dim(::Type{_StaticInt{N}}) where {N} = N::Int
 
-    using StaticArrayInterface: indices
+    struct _True end
+    struct _False end
+    _static(b::Bool) = b ? _True() : _False()
 
     include("ArrayStats/ArrayStats.jl")
     include("ArrayStats/nanmean.jl")

--- a/src/Sorting/nanmedian.jl
+++ b/src/Sorting/nanmedian.jl
@@ -156,11 +156,11 @@ function staticdim_median_quote(static_dims::Vector{Int}, N::Int)
   if !isempty(nonreduct_inds)
     firstn = first(nonreduct_inds)
     block = Expr(:block)
-    loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+    loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
     if length(nonreduct_inds) > 1
       for n ∈ @view(nonreduct_inds[2:end])
         newblock = Expr(:block)
-        push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+        push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
         block = newblock
       end
     end
@@ -184,20 +184,20 @@ function staticdim_median_quote(static_dims::Vector{Int}, N::Int)
 end
 
 # Chris Elrod metaprogramming magic:
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_median_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -205,7 +205,7 @@ function branches_median_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nanmedian!(B, A, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -227,7 +227,7 @@ function branches_median_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place median
-@generated function _nanmedian!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nanmedian!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   branches_median_quote(N, M, D)
 end
 @generated function _nanmedian!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, dims::Tuple{}) where {Tₒ,T,N}

--- a/src/Sorting/nanpctile.jl
+++ b/src/Sorting/nanpctile.jl
@@ -223,11 +223,11 @@ function staticdim_quantile_quote(static_dims::Vector{Int}, N::Int)
   if !isempty(nonreduct_inds)
     firstn = first(nonreduct_inds)
     block = Expr(:block)
-    loops = Expr(:for, :($(inds[firstn]) = indices((A,B),$firstn)), block)
+    loops = Expr(:for, :($(inds[firstn]) = axes(A,$firstn)), block)
     if length(nonreduct_inds) > 1
       for n ∈ @view(nonreduct_inds[2:end])
         newblock = Expr(:block)
-        push!(block.args, Expr(:for, :($(inds[n]) = indices((A,B),$n)), newblock))
+        push!(block.args, Expr(:for, :($(inds[n]) = axes(A,$n)), newblock))
         block = newblock
       end
     end
@@ -251,20 +251,20 @@ function staticdim_quantile_quote(static_dims::Vector{Int}, N::Int)
 end
 
 # Chris Elrod metaprogramming magic:
-# Turn non-static integers in `dims` tuple into `StaticInt`s
+# Turn non-static integers in `dims` tuple into `_StaticInt`s
 # so we can construct `static_dims` vector within @generated code
 function branches_quantile_quote(N::Int, M::Int, D)
   static_dims = Int[]
   for m ∈ 1:M
     param = D.parameters[m]
-    if param <: StaticInt
+    if param <: _StaticInt
       new_dim = _dim(param)::Int
       @assert new_dim ∉ static_dims
       push!(static_dims, new_dim)
     else
       t = Expr(:tuple)
       for n ∈ static_dims
-        push!(t.args, :(StaticInt{$n}()))
+        push!(t.args, :(_StaticInt{$n}()))
       end
       q = Expr(:block, :(dimm = dims[$m]))
       qold = q
@@ -272,7 +272,7 @@ function branches_quantile_quote(N::Int, M::Int, D)
       for n ∈ 1:N
         n ∈ static_dims && continue
         tc = copy(t)
-        push!(tc.args, :(StaticInt{$n}()))
+        push!(tc.args, :(_StaticInt{$n}()))
         qnew = Expr(ifsym, :(dimm == $n), :(return _nanquantile!(B, A, q, $tc)))
         for r ∈ m+1:M
           push!(tc.args, :(dims[$r]))
@@ -294,7 +294,7 @@ function branches_quantile_quote(N::Int, M::Int, D)
 end
 
 # Efficient @generated in-place quantile
-@generated function _nanquantile!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, q::Real, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{IntOrStaticInt,M}}}
+@generated function _nanquantile!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, q::Real, dims::D) where {Tₒ,T,N,M,D<:Tuple{Vararg{_IntOrStaticInt,M}}}
   branches_quantile_quote(N, M, D)
 end
 @generated function _nanquantile!(B::AbstractArray{Tₒ,N}, A::AbstractArray{T,N}, q::Real, dims::Tuple{}) where {Tₒ,T,N}


### PR DESCRIPTION
Hi! Noticed `using NaNStatistics` was invalidating a fair chunk of precompiled Base code on load. Tracked it down — both `Static.jl` and `StaticArrayInterface.jl` add lots of Base method overloads (Static alone overloads `promote_rule`, `zero`, `one`, `iszero`, `ifelse`, `|`, `&`, `convert`, `similar`, `eltype`, ~50 in total) and even pulls in `CommonWorldInvalidations` as a mitigation hack — which itself shows up as a top invalidation source.

Then I looked at how this package actually uses them, and it turns out we only need a tiny sliver:

- `StaticInt{N}` purely as an opaque type tag so `@generated` functions can specialize on `dims`
- `True` / `False` + `static(::Bool)` for one dispatch in `nanlogcumsumexp`
- `StaticArrayInterface.indices((A,B), n)` for loop ranges in the generated reductions — and B's non-reduct axes always match A's by construction here, so plain `axes(A, n)` works fine

That whole API surface is ~10 lines of local code with zero Base overloads:

```julia
struct StaticInt{N} end
StaticInt(N::Int) = StaticInt{N}()
const IntOrStaticInt = Union{Integer, StaticInt}
_dim(::Type{StaticInt{N}}) where {N} = N::Int

struct True end
struct False end
static(b::Bool) = b ? True() : False()

@inline indices(A::AbstractArray, n::Integer) = axes(A, n)
@inline indices(AB::Tuple{Vararg{AbstractArray}}, n::Integer) = axes(AB[1], n)
```

## Results

Measured with `SnoopCompileCore` on Julia 1.12:

| | Before | After |
| --- | --- | --- |
| Invalidation trees on `using NaNStatistics` | 41 | **0** |
| Methods invalidated | 3263 | **0** |

Top old offenders were Static's `convert`, `\|`, `&`, `ifelse`, `similar` and StaticArrayInterface's `setindex!` — all gone.

## Notes / caveats

- Anyone who happened to call `nanlogcumsumexp(A; reverse=Static.static(true))` or pass `Static.StaticInt`s as `dims` won't hit the new dispatch — but the public API takes plain `Bool` / `Int`, the static wrapping is internal, so this should be a non-issue in practice.
- Lost the static-size info that `StaticArrayInterface.indices` returns for static-sized arrays. For typical `Array{T,N}` workloads this shouldn't matter — `@simd ivdep` / `@inbounds` are still doing the heavy lifting in the inner loops. 

Let me know if you'd prefer a different approach (e.g. keeping `Static` as a weak dep)!